### PR TITLE
updated readme with correct css filename

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,7 +78,7 @@ In your html/template file, import the form CSS:
 
 .. code:: html
 
-    <link href="{% static 'tellme/feedback.css' %}" rel="stylesheet">
+    <link href="{% static 'tellme/feedback.min.css' %}" rel="stylesheet">
 
 In your html/template file, inside the <body> section:
 


### PR DESCRIPTION
This patch fixes the incorrect `feedback.css` filename referenced in the readme document.
