### PR TITLE
Include __pycache__/ and *.pyc in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ dist/
 django_tellme.egg-info/
 .DS_Store
 .idea/
+__pycache__/
+*.pyc


### PR DESCRIPTION
This commit include in .gitignore file __pycache__/ folder and *.pyc extension to be ignored.