### PR TITLE
Added settable mail function

### DIFF
--- a/tellme/mail.py
+++ b/tellme/mail.py
@@ -1,0 +1,23 @@
+from django.conf import settings
+from django.core.mail import send_mail as django_send_mail
+from django.utils.translation import ugettext_lazy as _
+try:
+    from django.core.urlresolvers import reverse
+except ImportError:
+    from django.urls import reverse
+
+
+def send_mail(request, feedback, fail_silently=True):
+    message = _("Your site %(host)s received feedback from %(user)s.\n"
+                "The comments were:\n"
+                "%(note)s.\n\n"
+                "See the full feedback content here: %(url)s")\
+              % {'host': request.get_host(), 'user': str(request.user), 'note': feedback.comment,
+                 'url': request.build_absolute_uri(
+                     reverse('admin:tellme_feedback_change', args=(feedback.id,)))}
+    django_send_mail(
+        _('[%(host)s] Received feedback') % {'host': request.get_host()},
+        message,
+        settings.SERVER_EMAIL,
+        [settings.TELLME_FEEDBACK_EMAIL],
+        fail_silently=fail_silently)

--- a/tellme/views.py
+++ b/tellme/views.py
@@ -2,18 +2,12 @@ import json
 from base64 import b64decode
 
 from django.conf import settings
-from django.core.mail import send_mail
-from django.utils.translation import ugettext_lazy as _
 from django.http import JsonResponse, HttpResponseBadRequest
 from django.core.files.base import ContentFile
 from django.utils.crypto import get_random_string
 
-try:
-    from django.core.urlresolvers import reverse
-except ImportError:
-    from django.urls import reverse
-
 from tellme.forms import FeedbackForm
+from tellme.mail import send_mail
 
 
 def post_feedback(request):
@@ -36,20 +30,7 @@ def post_feedback(request):
             f = form.save()
 
             if hasattr(settings, 'TELLME_FEEDBACK_EMAIL'):
-                message = _("Your site %(host)s received feedback from %(user)s.\n"
-                            "The comments were:\n"
-                            "%(note)s.\n\n"
-                            "See the full feedback content here: %(url)s")\
-                          % {'host': request.get_host(), 'user': str(request.user), 'note': feedback['note'],
-                             'url': request.build_absolute_uri(
-                                 reverse('admin:tellme_feedback_change', args=(f.id,)))}
-                send_mail(
-                        _('[%(host)s] Received feedback') % {'host': request.get_host()},
-                        message,
-                        settings.SERVER_EMAIL,
-                        [settings.TELLME_FEEDBACK_EMAIL],
-                        fail_silently=True)
-
+                send_mail(request, f)
             return JsonResponse({})
         else:
             return JsonResponse({'error': dict(form.errors)})


### PR DESCRIPTION
A user can set `settings. TELLME_MAIL_FUNCTION` to his/her function.
The default behavior is unchanged, but user can create any kind of notification he/she wants.

Ideas:
- Maybe I should rename that `TELLME_NOTIFICATION_FUNCTION` ?

This should be merged after PR #26 , to ensure everything is correct with unit tests.