### PR TITLE
Make the project Django 3 compatible

### DIFF
--- a/tellme/models.py
+++ b/tellme/models.py
@@ -3,7 +3,7 @@ from django.db import models
 from django.db.models.signals import post_delete
 from django.dispatch.dispatcher import receiver
 from django.utils.translation import ugettext_lazy as _
-from django.utils.encoding import python_2_unicode_compatible
+from six import python_2_unicode_compatible
 
 
 @python_2_unicode_compatible


### PR DESCRIPTION
> django.utils.six - Remove usage of this vendored library or switch to six.

https://docs.djangoproject.com/en/3.0/releases/3.0/#removed-private-python-2-compatibility-apis