### PR TITLE
Updated css location in README.rst.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,7 +78,7 @@ In your html/template file, import the form CSS:
 
 .. code:: html
 
-    <link href="{% static 'tellme/feedback.min.css' %}" rel="stylesheet">
+    <link href="{% static 'tellme/vendor/feedback/feedback.css' %}" rel="stylesheet">
 
 In your html/template file, inside the <body> section:
 


### PR DESCRIPTION
The location for django-tellme css was changed in version 7.0.0. However, this was not reflected in the docs. 

![Screenshot 2021-04-11 at 13 14 45](https://user-images.githubusercontent.com/9150431/114303826-f71d6400-9ac7-11eb-83ef-201f94d13fb2.png)
