### PR TITLE
Django 4.0 - method request.is_ajax has been removed

### DIFF
--- a/tellme/views.py
+++ b/tellme/views.py
@@ -24,7 +24,7 @@ def get_notification_function(path=None):
 
 
 def post_feedback(request):
-    if request.method == 'POST' and request.is_ajax():
+    if request.method == 'POST':
 
         # Copy Post data names into names used into the model in order to automatically create the model/form
         # from the request dicts

--- a/tellme/views.py
+++ b/tellme/views.py
@@ -24,7 +24,7 @@ def get_notification_function(path=None):
 
 
 def post_feedback(request):
-    if request.method == 'POST':
+    if request.method == 'POST' and request.headers.get('x-requested-with') == 'XMLHttpRequest':
 
         # Copy Post data names into names used into the model in order to automatically create the model/form
         # from the request dicts


### PR DESCRIPTION
Deprecation notice since django 3.1: https://docs.djangoproject.com/en/4.0/releases/3.1/#id2